### PR TITLE
ci(docker): build docker image using `docker/build-push-action` and its cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,9 @@ name: "⚒️ Deploy image to Dockerhub and GHCR"
 
 on:
   push:
-    tags:
-      - "*"
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:
@@ -13,7 +14,18 @@ jobs:
       - name: Checkout GitHub Action
         uses: actions/checkout@main
 
+      - name: Generate Docker Metadata
+        id: docker_metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=gounux/gischat,enable=${{ github.event_name == 'release' }}
+            name=ghcr.io/geotribu/gischat,enable=true
+          flavor: latest=auto
+          tags: type=semver,pattern={{version}}
+
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'release' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -27,13 +39,9 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push image
-        run: |
-          docker build . \
-            --tag gounux/gischat:$(poetry version -s) \
-            --tag gounux/gischat:latest \
-            --tag ghcr.io/geotribu/gischat:$(poetry version -s) \
-            --tag ghcr.io/geotribu/gischat:latest
-          docker push gounux/gischat:$(poetry version -s)
-          docker push gounux/gischat:latest
-          docker push ghcr.io/geotribu/gischat:$(poetry version -s)
-          docker push ghcr.io/geotribu/gischat:latest
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.docker_metadata.outputs.tags }}
+          cache-from: type=registry,ref=ghcr.io/geotribu/gischat:buildcache
+          cache-to: type=registry,ref=ghcr.io/geotribu/gischat:buildcache,mode=max


### PR DESCRIPTION
Make the build CI more efficient by using cache and GitHub's variables.