### PR TITLE
edit(directory): reference available qchat channels on the official instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Gischat API backend for chatting with your tribe in GIS tools.
 
 Here are the known clients implementing gischat / QChat, at the moment:
 
-- [QChat](https://github.com/geotribu/qchat) QGIS plugin.
-- [QTribu](https://github.com/geotribu/qtribu) QGIS plugin, available [from the official QGIS plugin repository](https://plugins.qgis.org/plugins/qtribu/).
+- [QChat](https://github.com/geotribu/qchat) QGIS plugin, available [from the official QGIS plugin repository](https://plugins.qgis.org/plugins/qchat/).
 - [QField plugin](https://github.com/geotribu/qchat-qfield-plugin).
 
 And other to come!
@@ -32,8 +31,7 @@ Following instances are up and running :
 
 | URL | Description | Location |
 | :-: | :---------- | :------- |
-| <https://gischat.geotribu.net> | Geotribu's international instance | Germany |
-| <https://gischat.geotribu.fr> | Geotribu's fr-speaking instance | Germany |
+| <https://qchat.geotribu.net> | Geotribu's official instance | Germany |
 
 ## Developer information
 

--- a/instances.json
+++ b/instances.json
@@ -1,8 +1,38 @@
 {
+  "be": [
+    "https://qchat.geotribu.net"
+  ],
+  "bg": [
+    "https://qchat.geotribu.net"
+  ],
+  "ch": [
+    "https://qchat.geotribu.net"
+  ],
+  "de": [
+    "https://qchat.geotribu.net"
+  ],
+  "dk": [
+    "https://qchat.geotribu.net"
+  ],
   "en": [
-    "https://gischat.geotribu.net"
+    "https://qchat.geotribu.net"
+  ],
+  "es": [
+    "https://qchat.geotribu.net"
   ],
   "fr": [
-    "https://gischat.geotribu.fr"
+    "https://qchat.geotribu.net"
+  ],
+  "it": [
+    "https://qchat.geotribu.net"
+  ],
+  "nl": [
+    "https://qchat.geotribu.net"
+  ],
+  "pl": [
+    "https://qchat.geotribu.net"
+  ],
+  "pt": [
+    "https://qchat.geotribu.net"
   ]
 }


### PR DESCRIPTION
Update the instances directory and README.md to fit the unique `qchat.geotribu.net` instance. 