### PR TITLE
ci(gischat): add python 3.14 to tests matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,8 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-            - "3.11"
             - "3.12"
-            - "3.13"
+            - "3.14"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Testing with 3.12 and 3.14, removing 3.11 & 3.13 since we don't need to overload GH CI Actions,