### PR TITLE
fix: fix redis timeouts and keepalive

### DIFF
--- a/gischat/app.py
+++ b/gischat/app.py
@@ -131,8 +131,8 @@ async def redis_listener(app: FastAPI) -> None:
     """
 
     while True:
+        pubsub = app.state.redis_sub.pubsub()
         try:
-            pubsub = app.state.redis_sub.pubsub()
             redis_channel = get_redis_channel_key()
 
             await pubsub.subscribe(redis_channel)
@@ -156,6 +156,8 @@ async def redis_listener(app: FastAPI) -> None:
         except Exception as e:
             logger.error(f"❌ Redis listener crashed, restarting in 1s: {e}")
             await asyncio.sleep(1)
+        finally:
+            await pubsub.aclose()
 
 
 # region API endpoints

--- a/gischat/app.py
+++ b/gischat/app.py
@@ -79,7 +79,13 @@ async def lifespan(app: FastAPI):
     # startup
     logger.info("🚀 Starting lifespan, connecting to Redis...")
     app.state.redis_pub = await redis.from_url(REDIS_URL, decode_responses=True)
-    app.state.redis_sub = await redis.from_url(REDIS_URL, decode_responses=True)
+    app.state.redis_sub = await redis.from_url(
+        REDIS_URL,
+        decode_responses=True,
+        socket_timeout=None,
+        socket_keepalive=True,
+        health_check_interval=30,
+    )
 
     redis_connection = RedisObject(
         host=REDIS_HOST,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gischat"
-version = "3.4.0"
+version = "3.4.1"
 description = "QChat backend for QGIS and QField plugins"
 authors = [{ name = "Guilhem Allaman", email = "contact@guilhemallaman.net" }]
 requires-python = ">=3.12,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "gischat"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio" },


### PR DESCRIPTION
Fixing the numerous restarts spotted in the staging log,

```
gischat-app-staging  | [2026-06-13 05:28:19,251] [ERROR] ❌ Redis listener crashed, restarting in 1s: Timeout reading from redis:6379
gischat-app-staging  | [2026-06-13 05:28:19,602] [ERROR] ❌ Redis listener crashed, restarting in 1s: Timeout reading from redis:6379
gischat-app-staging  | [2026-06-13 05:28:20,268] [INFO] ✅ Redis listener running...
gischat-app-staging  | [2026-06-13 05:28:20,624] [INFO] ✅ Redis listener running...
```

See https://redis.readthedocs.io/en/latest/connections.html